### PR TITLE
ci: auto-merge non-major Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,31 @@
+name: Dependabot Auto-Merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@ffa630c65fa7e0ecfa0625b5ceda64399aea1b36 # v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Approve PR
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr review --approve "$PR_URL"
+
+      - name: Enable auto-merge for non-major updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
## Summary

- Auto-approve all Dependabot PRs and auto-merge patch/minor updates after required checks pass
- Major version bumps are left for manual review
- Pattern follows GitHub's official docs and well-maintained OSS projects (trpc, spatie, etc.)

## How it works

1. Dependabot opens a PR
2. This workflow approves it and flags non-major updates for auto-merge
3. `gh pr merge --auto` waits for all required status checks (pytest, ruff, docker-build, snyk-code, snyk-sca) to pass
4. Once green, GitHub merges automatically

Major bumps (e.g., pandas 2.x -> 3.x) still get approved but are NOT auto-merged — they require manual review.

## Test plan

- [ ] CI passes on this PR
- [ ] Next Dependabot PR triggers the workflow and auto-merges if non-major