### PR TITLE
fix: resolve P0-critical bugs (#15, #16, #17)

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,11 +1,24 @@
+import sqlite3
+
 from flask import Flask
 from flask_login import LoginManager
 from flask_sqlalchemy import SQLAlchemy
 from flask_wtf.csrf import CSRFProtect
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
 
 db = SQLAlchemy()
 login_manager = LoginManager()
 csrf = CSRFProtect()
+
+
+@event.listens_for(Engine, "connect")
+def _set_sqlite_pragma(dbapi_connection, connection_record):
+    if isinstance(dbapi_connection, sqlite3.Connection):
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.execute("PRAGMA journal_mode=WAL")
+        cursor.close()
 
 
 def _add_missing_columns():

--- a/app/data.py
+++ b/app/data.py
@@ -96,7 +96,7 @@ def compute_castaway_stats(s_conf, s_vh, s_cr, s_am, idol_ids):
         else pd.Series(dtype=int)
     )
     votes_against = (
-        s_vh.groupby("vote_id").size() if not s_vh.empty else pd.Series(dtype=int)
+        s_vh.groupby("voted_out_id").size() if not s_vh.empty else pd.Series(dtype=int)
     )
     indiv_imm = (
         s_cr[s_cr["won_individual_immunity"] == 1].groupby("castaway_id").size()

--- a/app/routes.py
+++ b/app/routes.py
@@ -573,7 +573,7 @@ def rules(season_id):
     # Compute example values for the rules page (skip if merge data unknown)
     examples = {}
     if season and season.merge_threshold is not None:
-        scoring = get_scoring_system(season)
+        scoring = get_scoring_system(season.scoring_system, season.get_scoring_config())
         mt = season.merge_threshold
 
         if progressive:

--- a/app/scoring/__init__.py
+++ b/app/scoring/__init__.py
@@ -7,7 +7,7 @@ _registry = {s.name: type(s) for s in SCORING_SYSTEMS}
 
 def get_scoring_system(name, config=None):
     cls = _registry.get(name, ClassicScoring)
-    if config:
+    if config is not None:
         return cls(**config)
     return cls()
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,239 @@
+"""Tests for app/data.py — compute_castaway_stats aggregation logic."""
+
+import pandas as pd
+
+from app.data import compute_castaway_stats
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+
+def _empty_df(*cols):
+    """Return an empty DataFrame with the given columns."""
+    return pd.DataFrame(columns=cols)
+
+
+def _vote_history(rows):
+    """Build a Vote History DataFrame from (vote_id, voted_out_id) tuples."""
+    return pd.DataFrame(rows, columns=["vote_id", "voted_out_id"])
+
+
+def _confessionals(rows):
+    """Build a Confessionals DataFrame from (castaway_id, confessional_count) tuples."""
+    return pd.DataFrame(rows, columns=["castaway_id", "confessional_count"])
+
+
+def _challenge_results(rows):
+    """Build a Challenge Results DataFrame from (castaway_id, won_ii, won_ti) tuples."""
+    return pd.DataFrame(
+        rows,
+        columns=["castaway_id", "won_individual_immunity", "won_tribal_immunity"],
+    )
+
+
+def _advantage_movement(rows):
+    """Build an Advantage Movement DataFrame from (castaway_id, advantage_id, event) tuples."""
+    return pd.DataFrame(rows, columns=["castaway_id", "advantage_id", "event"])
+
+
+EMPTY_CONF = _empty_df("castaway_id", "confessional_count")
+EMPTY_VH = _empty_df("vote_id", "voted_out_id")
+EMPTY_CR = _empty_df("castaway_id", "won_individual_immunity", "won_tribal_immunity")
+EMPTY_AM = _empty_df("castaway_id", "advantage_id", "event")
+NO_IDOLS = set()
+
+
+# ── votes_against: groups by target (voted_out_id), not voter (vote_id) ───
+
+
+class TestVotesAgainst:
+    def test_counts_votes_received_not_cast(self):
+        """Core regression: voter A votes for target B — B gets the count, not A."""
+        vh = _vote_history([
+            ("US0001", "US0002"),  # A votes for B
+            ("US0003", "US0002"),  # C votes for B
+            ("US0002", "US0003"),  # B votes for C
+        ])
+        result = compute_castaway_stats(EMPTY_CONF, vh, EMPTY_CR, EMPTY_AM, NO_IDOLS)
+        va = result["votes_against"]
+        assert va.get("US0002") == 2  # B received 2 votes
+        assert va.get("US0003") == 1  # C received 1 vote
+        assert va.get("US0001", 0) == 0  # A received 0 votes
+
+    def test_single_vote(self):
+        vh = _vote_history([("US0001", "US0002")])
+        result = compute_castaway_stats(EMPTY_CONF, vh, EMPTY_CR, EMPTY_AM, NO_IDOLS)
+        assert result["votes_against"].get("US0002") == 1
+        assert result["votes_against"].get("US0001", 0) == 0
+
+    def test_unanimous_vote(self):
+        """All voters target the same person."""
+        vh = _vote_history([
+            ("US0001", "US0005"),
+            ("US0002", "US0005"),
+            ("US0003", "US0005"),
+            ("US0004", "US0005"),
+        ])
+        result = compute_castaway_stats(EMPTY_CONF, vh, EMPTY_CR, EMPTY_AM, NO_IDOLS)
+        assert result["votes_against"].get("US0005") == 4
+
+    def test_split_vote(self):
+        """Two targets receive different numbers of votes."""
+        vh = _vote_history([
+            ("US0001", "US0003"),
+            ("US0002", "US0003"),
+            ("US0003", "US0001"),
+            ("US0004", "US0001"),
+            ("US0005", "US0001"),
+        ])
+        result = compute_castaway_stats(EMPTY_CONF, vh, EMPTY_CR, EMPTY_AM, NO_IDOLS)
+        va = result["votes_against"]
+        assert va.get("US0001") == 3
+        assert va.get("US0003") == 2
+
+    def test_empty_vote_history(self):
+        result = compute_castaway_stats(EMPTY_CONF, EMPTY_VH, EMPTY_CR, EMPTY_AM, NO_IDOLS)
+        assert result["votes_against"].empty
+
+    def test_self_vote(self):
+        """Edge case: a player votes for themselves (shouldn't happen, but data may contain it)."""
+        vh = _vote_history([("US0001", "US0001")])
+        result = compute_castaway_stats(EMPTY_CONF, vh, EMPTY_CR, EMPTY_AM, NO_IDOLS)
+        assert result["votes_against"].get("US0001") == 1
+
+
+# ── confessionals ─────────────────────────────────────────────────────────
+
+
+class TestConfessionals:
+    def test_sums_across_episodes(self):
+        conf = _confessionals([
+            ("US0001", 3),
+            ("US0001", 5),
+            ("US0002", 2),
+        ])
+        result = compute_castaway_stats(conf, EMPTY_VH, EMPTY_CR, EMPTY_AM, NO_IDOLS)
+        assert result["conf_totals"].get("US0001") == 8
+        assert result["conf_totals"].get("US0002") == 2
+
+    def test_empty_confessionals(self):
+        result = compute_castaway_stats(EMPTY_CONF, EMPTY_VH, EMPTY_CR, EMPTY_AM, NO_IDOLS)
+        assert result["conf_totals"].empty
+
+
+# ── challenge results ─────────────────────────────────────────────────────
+
+
+class TestChallengeResults:
+    def test_individual_immunity(self):
+        cr = _challenge_results([
+            ("US0001", 1, 0),
+            ("US0001", 1, 0),
+            ("US0002", 0, 0),
+        ])
+        result = compute_castaway_stats(EMPTY_CONF, EMPTY_VH, cr, EMPTY_AM, NO_IDOLS)
+        assert result["indiv_imm"].get("US0001") == 2
+        assert result["indiv_imm"].get("US0002", 0) == 0
+
+    def test_tribal_immunity(self):
+        cr = _challenge_results([
+            ("US0001", 0, 1),
+            ("US0001", 0, 1),
+            ("US0001", 0, 1),
+        ])
+        result = compute_castaway_stats(EMPTY_CONF, EMPTY_VH, cr, EMPTY_AM, NO_IDOLS)
+        assert result["tribal_imm"].get("US0001") == 3
+
+    def test_empty_challenge_results(self):
+        result = compute_castaway_stats(EMPTY_CONF, EMPTY_VH, EMPTY_CR, EMPTY_AM, NO_IDOLS)
+        assert result["indiv_imm"].empty
+        assert result["tribal_imm"].empty
+
+
+# ── advantage movement ────────────────────────────────────────────────────
+
+
+class TestAdvantageMovement:
+    def test_idol_found_and_played(self):
+        idol_ids = {"idol_001", "idol_002"}
+        am = _advantage_movement([
+            ("US0001", "idol_001", "Found"),
+            ("US0001", "idol_001", "Played"),
+            ("US0001", "idol_002", "Found"),
+        ])
+        result = compute_castaway_stats(EMPTY_CONF, EMPTY_VH, EMPTY_CR, am, idol_ids)
+        assert result["idols_found"].get("US0001") == 2
+        assert result["idols_played"].get("US0001") == 1
+
+    def test_non_idol_advantage(self):
+        idol_ids = {"idol_001"}
+        am = _advantage_movement([
+            ("US0001", "adv_001", "Found"),
+            ("US0001", "adv_001", "Played"),
+        ])
+        result = compute_castaway_stats(EMPTY_CONF, EMPTY_VH, EMPTY_CR, am, idol_ids)
+        assert result["adv_found"].get("US0001") == 1
+        assert result["adv_played"].get("US0001") == 1
+        assert result["idols_found"].get("US0001", 0) == 0
+
+    def test_idol_vs_advantage_separation(self):
+        """Idols and non-idol advantages are counted separately."""
+        idol_ids = {"idol_001"}
+        am = _advantage_movement([
+            ("US0001", "idol_001", "Found"),
+            ("US0001", "adv_001", "Found"),
+            ("US0001", "idol_001", "Played"),
+            ("US0001", "adv_001", "Played"),
+        ])
+        result = compute_castaway_stats(EMPTY_CONF, EMPTY_VH, EMPTY_CR, am, idol_ids)
+        assert result["idols_found"].get("US0001") == 1
+        assert result["idols_played"].get("US0001") == 1
+        assert result["adv_found"].get("US0001") == 1
+        assert result["adv_played"].get("US0001") == 1
+
+    def test_empty_advantage_movement(self):
+        result = compute_castaway_stats(EMPTY_CONF, EMPTY_VH, EMPTY_CR, EMPTY_AM, NO_IDOLS)
+        assert result["idols_found"].empty
+        assert result["adv_found"].empty
+
+    def test_found_keyword_matching(self):
+        """'Found' matching uses str.contains, so 'Found On Ground' should count."""
+        idol_ids = {"idol_001"}
+        am = _advantage_movement([
+            ("US0001", "idol_001", "Found On Ground"),
+        ])
+        result = compute_castaway_stats(EMPTY_CONF, EMPTY_VH, EMPTY_CR, am, idol_ids)
+        assert result["idols_found"].get("US0001") == 1
+
+
+# ── all stats together ────────────────────────────────────────────────────
+
+
+class TestFullIntegration:
+    def test_all_stats_computed_together(self):
+        """Verify all stat categories work in concert."""
+        idol_ids = {"idol_001"}
+        conf = _confessionals([("US0001", 5), ("US0002", 3)])
+        vh = _vote_history([("US0001", "US0002"), ("US0003", "US0002")])
+        cr = _challenge_results([("US0001", 1, 0), ("US0002", 0, 1)])
+        am = _advantage_movement([
+            ("US0001", "idol_001", "Found"),
+            ("US0002", "adv_001", "Found"),
+        ])
+        result = compute_castaway_stats(conf, vh, cr, am, idol_ids)
+        assert result["conf_totals"].get("US0001") == 5
+        assert result["votes_against"].get("US0002") == 2
+        assert result["indiv_imm"].get("US0001") == 1
+        assert result["tribal_imm"].get("US0002") == 1
+        assert result["idols_found"].get("US0001") == 1
+        assert result["adv_found"].get("US0002") == 1
+
+    def test_all_empty_returns_empty_series(self):
+        result = compute_castaway_stats(
+            EMPTY_CONF, EMPTY_VH, EMPTY_CR, EMPTY_AM, NO_IDOLS
+        )
+        for key in [
+            "conf_totals", "votes_against", "indiv_imm", "tribal_imm",
+            "idols_found", "idols_played", "adv_found", "adv_played",
+        ]:
+            assert result[key].empty

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -48,11 +48,13 @@ NO_IDOLS = set()
 class TestVotesAgainst:
     def test_counts_votes_received_not_cast(self):
         """Core regression: voter A votes for target B — B gets the count, not A."""
-        vh = _vote_history([
-            ("US0001", "US0002"),  # A votes for B
-            ("US0003", "US0002"),  # C votes for B
-            ("US0002", "US0003"),  # B votes for C
-        ])
+        vh = _vote_history(
+            [
+                ("US0001", "US0002"),  # A votes for B
+                ("US0003", "US0002"),  # C votes for B
+                ("US0002", "US0003"),  # B votes for C
+            ]
+        )
         result = compute_castaway_stats(EMPTY_CONF, vh, EMPTY_CR, EMPTY_AM, NO_IDOLS)
         va = result["votes_against"]
         assert va.get("US0002") == 2  # B received 2 votes
@@ -67,31 +69,37 @@ class TestVotesAgainst:
 
     def test_unanimous_vote(self):
         """All voters target the same person."""
-        vh = _vote_history([
-            ("US0001", "US0005"),
-            ("US0002", "US0005"),
-            ("US0003", "US0005"),
-            ("US0004", "US0005"),
-        ])
+        vh = _vote_history(
+            [
+                ("US0001", "US0005"),
+                ("US0002", "US0005"),
+                ("US0003", "US0005"),
+                ("US0004", "US0005"),
+            ]
+        )
         result = compute_castaway_stats(EMPTY_CONF, vh, EMPTY_CR, EMPTY_AM, NO_IDOLS)
         assert result["votes_against"].get("US0005") == 4
 
     def test_split_vote(self):
         """Two targets receive different numbers of votes."""
-        vh = _vote_history([
-            ("US0001", "US0003"),
-            ("US0002", "US0003"),
-            ("US0003", "US0001"),
-            ("US0004", "US0001"),
-            ("US0005", "US0001"),
-        ])
+        vh = _vote_history(
+            [
+                ("US0001", "US0003"),
+                ("US0002", "US0003"),
+                ("US0003", "US0001"),
+                ("US0004", "US0001"),
+                ("US0005", "US0001"),
+            ]
+        )
         result = compute_castaway_stats(EMPTY_CONF, vh, EMPTY_CR, EMPTY_AM, NO_IDOLS)
         va = result["votes_against"]
         assert va.get("US0001") == 3
         assert va.get("US0003") == 2
 
     def test_empty_vote_history(self):
-        result = compute_castaway_stats(EMPTY_CONF, EMPTY_VH, EMPTY_CR, EMPTY_AM, NO_IDOLS)
+        result = compute_castaway_stats(
+            EMPTY_CONF, EMPTY_VH, EMPTY_CR, EMPTY_AM, NO_IDOLS
+        )
         assert result["votes_against"].empty
 
     def test_self_vote(self):
@@ -106,17 +114,21 @@ class TestVotesAgainst:
 
 class TestConfessionals:
     def test_sums_across_episodes(self):
-        conf = _confessionals([
-            ("US0001", 3),
-            ("US0001", 5),
-            ("US0002", 2),
-        ])
+        conf = _confessionals(
+            [
+                ("US0001", 3),
+                ("US0001", 5),
+                ("US0002", 2),
+            ]
+        )
         result = compute_castaway_stats(conf, EMPTY_VH, EMPTY_CR, EMPTY_AM, NO_IDOLS)
         assert result["conf_totals"].get("US0001") == 8
         assert result["conf_totals"].get("US0002") == 2
 
     def test_empty_confessionals(self):
-        result = compute_castaway_stats(EMPTY_CONF, EMPTY_VH, EMPTY_CR, EMPTY_AM, NO_IDOLS)
+        result = compute_castaway_stats(
+            EMPTY_CONF, EMPTY_VH, EMPTY_CR, EMPTY_AM, NO_IDOLS
+        )
         assert result["conf_totals"].empty
 
 
@@ -125,26 +137,32 @@ class TestConfessionals:
 
 class TestChallengeResults:
     def test_individual_immunity(self):
-        cr = _challenge_results([
-            ("US0001", 1, 0),
-            ("US0001", 1, 0),
-            ("US0002", 0, 0),
-        ])
+        cr = _challenge_results(
+            [
+                ("US0001", 1, 0),
+                ("US0001", 1, 0),
+                ("US0002", 0, 0),
+            ]
+        )
         result = compute_castaway_stats(EMPTY_CONF, EMPTY_VH, cr, EMPTY_AM, NO_IDOLS)
         assert result["indiv_imm"].get("US0001") == 2
         assert result["indiv_imm"].get("US0002", 0) == 0
 
     def test_tribal_immunity(self):
-        cr = _challenge_results([
-            ("US0001", 0, 1),
-            ("US0001", 0, 1),
-            ("US0001", 0, 1),
-        ])
+        cr = _challenge_results(
+            [
+                ("US0001", 0, 1),
+                ("US0001", 0, 1),
+                ("US0001", 0, 1),
+            ]
+        )
         result = compute_castaway_stats(EMPTY_CONF, EMPTY_VH, cr, EMPTY_AM, NO_IDOLS)
         assert result["tribal_imm"].get("US0001") == 3
 
     def test_empty_challenge_results(self):
-        result = compute_castaway_stats(EMPTY_CONF, EMPTY_VH, EMPTY_CR, EMPTY_AM, NO_IDOLS)
+        result = compute_castaway_stats(
+            EMPTY_CONF, EMPTY_VH, EMPTY_CR, EMPTY_AM, NO_IDOLS
+        )
         assert result["indiv_imm"].empty
         assert result["tribal_imm"].empty
 
@@ -155,21 +173,25 @@ class TestChallengeResults:
 class TestAdvantageMovement:
     def test_idol_found_and_played(self):
         idol_ids = {"idol_001", "idol_002"}
-        am = _advantage_movement([
-            ("US0001", "idol_001", "Found"),
-            ("US0001", "idol_001", "Played"),
-            ("US0001", "idol_002", "Found"),
-        ])
+        am = _advantage_movement(
+            [
+                ("US0001", "idol_001", "Found"),
+                ("US0001", "idol_001", "Played"),
+                ("US0001", "idol_002", "Found"),
+            ]
+        )
         result = compute_castaway_stats(EMPTY_CONF, EMPTY_VH, EMPTY_CR, am, idol_ids)
         assert result["idols_found"].get("US0001") == 2
         assert result["idols_played"].get("US0001") == 1
 
     def test_non_idol_advantage(self):
         idol_ids = {"idol_001"}
-        am = _advantage_movement([
-            ("US0001", "adv_001", "Found"),
-            ("US0001", "adv_001", "Played"),
-        ])
+        am = _advantage_movement(
+            [
+                ("US0001", "adv_001", "Found"),
+                ("US0001", "adv_001", "Played"),
+            ]
+        )
         result = compute_castaway_stats(EMPTY_CONF, EMPTY_VH, EMPTY_CR, am, idol_ids)
         assert result["adv_found"].get("US0001") == 1
         assert result["adv_played"].get("US0001") == 1
@@ -178,12 +200,14 @@ class TestAdvantageMovement:
     def test_idol_vs_advantage_separation(self):
         """Idols and non-idol advantages are counted separately."""
         idol_ids = {"idol_001"}
-        am = _advantage_movement([
-            ("US0001", "idol_001", "Found"),
-            ("US0001", "adv_001", "Found"),
-            ("US0001", "idol_001", "Played"),
-            ("US0001", "adv_001", "Played"),
-        ])
+        am = _advantage_movement(
+            [
+                ("US0001", "idol_001", "Found"),
+                ("US0001", "adv_001", "Found"),
+                ("US0001", "idol_001", "Played"),
+                ("US0001", "adv_001", "Played"),
+            ]
+        )
         result = compute_castaway_stats(EMPTY_CONF, EMPTY_VH, EMPTY_CR, am, idol_ids)
         assert result["idols_found"].get("US0001") == 1
         assert result["idols_played"].get("US0001") == 1
@@ -191,16 +215,20 @@ class TestAdvantageMovement:
         assert result["adv_played"].get("US0001") == 1
 
     def test_empty_advantage_movement(self):
-        result = compute_castaway_stats(EMPTY_CONF, EMPTY_VH, EMPTY_CR, EMPTY_AM, NO_IDOLS)
+        result = compute_castaway_stats(
+            EMPTY_CONF, EMPTY_VH, EMPTY_CR, EMPTY_AM, NO_IDOLS
+        )
         assert result["idols_found"].empty
         assert result["adv_found"].empty
 
     def test_found_keyword_matching(self):
         """'Found' matching uses str.contains, so 'Found On Ground' should count."""
         idol_ids = {"idol_001"}
-        am = _advantage_movement([
-            ("US0001", "idol_001", "Found On Ground"),
-        ])
+        am = _advantage_movement(
+            [
+                ("US0001", "idol_001", "Found On Ground"),
+            ]
+        )
         result = compute_castaway_stats(EMPTY_CONF, EMPTY_VH, EMPTY_CR, am, idol_ids)
         assert result["idols_found"].get("US0001") == 1
 
@@ -215,10 +243,12 @@ class TestFullIntegration:
         conf = _confessionals([("US0001", 5), ("US0002", 3)])
         vh = _vote_history([("US0001", "US0002"), ("US0003", "US0002")])
         cr = _challenge_results([("US0001", 1, 0), ("US0002", 0, 1)])
-        am = _advantage_movement([
-            ("US0001", "idol_001", "Found"),
-            ("US0002", "adv_001", "Found"),
-        ])
+        am = _advantage_movement(
+            [
+                ("US0001", "idol_001", "Found"),
+                ("US0002", "adv_001", "Found"),
+            ]
+        )
         result = compute_castaway_stats(conf, vh, cr, am, idol_ids)
         assert result["conf_totals"].get("US0001") == 5
         assert result["votes_against"].get("US0002") == 2
@@ -232,7 +262,13 @@ class TestFullIntegration:
             EMPTY_CONF, EMPTY_VH, EMPTY_CR, EMPTY_AM, NO_IDOLS
         )
         for key in [
-            "conf_totals", "votes_against", "indiv_imm", "tribal_imm",
-            "idols_found", "idols_played", "adv_found", "adv_played",
+            "conf_totals",
+            "votes_against",
+            "indiv_imm",
+            "tribal_imm",
+            "idols_found",
+            "idols_played",
+            "adv_found",
+            "adv_played",
         ]:
             assert result[key].empty

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -4,7 +4,6 @@ import pandas as pd
 
 from app.data import compute_castaway_stats
 
-
 # ── Helpers ────────────────────────────────────────────────────────────────
 
 

--- a/tests/test_pragmas.py
+++ b/tests/test_pragmas.py
@@ -7,7 +7,6 @@ import pytest
 from sqlalchemy import text
 from sqlalchemy.exc import IntegrityError
 
-
 # ── Fixtures ──────────────────────────────────────────────────────────────
 
 

--- a/tests/test_pragmas.py
+++ b/tests/test_pragmas.py
@@ -1,0 +1,147 @@
+"""Tests for SQLite PRAGMA configuration — foreign keys and WAL mode (#17)."""
+
+import importlib
+import sys
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def app(tmp_path, monkeypatch):
+    """Flask app with a temp file-backed SQLite DB.
+
+    Must reload the config module after setting DATABASE_URL, because
+    Config class attributes are evaluated at import time and cached in
+    sys.modules.  Also patches out the scheduler to avoid background threads.
+    """
+    db_path = tmp_path / "test.db"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+
+    # Force config module to re-evaluate with the new env var
+    if "config" in sys.modules:
+        importlib.reload(sys.modules["config"])
+
+    # Prevent scheduler from starting during tests
+    monkeypatch.setattr("app.scheduler.init_scheduler", lambda _app: None)
+
+    from app import create_app, db
+
+    application = create_app()
+    application.config["TESTING"] = True
+    with application.app_context():
+        yield application, db
+        db.session.remove()
+
+    # Restore original config for other test modules
+    if "config" in sys.modules:
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        importlib.reload(sys.modules["config"])
+
+
+# ── PRAGMA foreign_keys ───────────────────────────────────────────────────
+
+
+class TestForeignKeys:
+    def test_pragma_foreign_keys_is_on(self, app):
+        """PRAGMA foreign_keys should return 1 on every connection."""
+        _, db = app
+        result = db.session.execute(text("PRAGMA foreign_keys")).scalar()
+        assert result == 1
+
+    def test_fk_violation_raises_integrity_error(self, app):
+        """Inserting a Survivor with a nonexistent season_id should fail."""
+        _, db = app
+        from app.models import Survivor
+
+        bad_survivor = Survivor(
+            season_id=9999,
+            name="Ghost",
+            voted_out_order=0,
+        )
+        db.session.add(bad_survivor)
+        with pytest.raises(IntegrityError, match="FOREIGN KEY"):
+            db.session.flush()
+        db.session.rollback()
+
+    def test_fk_enforced_on_fresh_session(self, app):
+        """FK enforcement persists after session cycling."""
+        _, db = app
+        db.session.remove()
+        result = db.session.execute(text("PRAGMA foreign_keys")).scalar()
+        assert result == 1
+
+    def test_fk_enforced_on_pick_without_user(self, app):
+        """Pick with nonexistent user_id should be rejected."""
+        _, db = app
+        from app.models import Pick, Season, Survivor
+
+        season = Season(number=99, name="Test", num_players=18)
+        db.session.add(season)
+        db.session.flush()
+
+        survivor = Survivor(season_id=season.id, name="Castaway", voted_out_order=0)
+        db.session.add(survivor)
+        db.session.flush()
+
+        bad_pick = Pick(
+            user_id=9999,
+            season_id=season.id,
+            survivor_id=survivor.id,
+            pick_type="draft",
+        )
+        db.session.add(bad_pick)
+        with pytest.raises(IntegrityError, match="FOREIGN KEY"):
+            db.session.flush()
+        db.session.rollback()
+
+
+# ── PRAGMA journal_mode ───────────────────────────────────────────────────
+
+
+class TestJournalMode:
+    def test_wal_mode_active(self, app):
+        """WAL mode should be active on the file-backed test database."""
+        _, db = app
+        mode = db.session.execute(text("PRAGMA journal_mode")).scalar()
+        assert mode == "wal"
+
+    def test_wal_persists_across_sessions(self, app):
+        """WAL should still be active after session cycling."""
+        _, db = app
+        db.session.remove()
+        mode = db.session.execute(text("PRAGMA journal_mode")).scalar()
+        assert mode == "wal"
+
+
+# ── Both PRAGMAs on raw connection ────────────────────────────────────────
+
+
+class TestRawConnection:
+    def test_pragmas_on_raw_dbapi_connection(self, app):
+        """Verify PRAGMAs are set on the underlying DBAPI connection, not just via ORM."""
+        _, db = app
+        connection = db.engine.raw_connection()
+        try:
+            cursor = connection.cursor()
+            cursor.execute("PRAGMA foreign_keys")
+            assert cursor.fetchone()[0] == 1
+            cursor.execute("PRAGMA journal_mode")
+            assert cursor.fetchone()[0] == "wal"
+        finally:
+            connection.close()
+
+
+# ── Test DB isolation ─────────────────────────────────────────────────────
+
+
+class TestDbIsolation:
+    def test_uses_temp_db_not_project_db(self, app, tmp_path):
+        """Verify the app is actually using the temp DB, not the project root's DB."""
+        application, _ = app
+        uri = application.config["SQLALCHEMY_DATABASE_URI"]
+        assert str(tmp_path) in uri

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -805,6 +805,33 @@ class TestGetScoringSystem:
         scoring = get_scoring_system("Classic")
         assert scoring.config["first_val"] == DEFAULT_CONFIG["first_val"]
 
+    def test_empty_dict_config_uses_defaults(self):
+        """Empty dict is not None — cls(**{}) should still produce valid defaults."""
+        scoring = get_scoring_system("Classic", config={})
+        assert scoring.config["first_val"] == DEFAULT_CONFIG["first_val"]
+
+    def test_none_config_uses_defaults(self):
+        """Explicit None should behave like omitting config."""
+        scoring = get_scoring_system("Classic", config=None)
+        assert scoring.config["first_val"] == DEFAULT_CONFIG["first_val"]
+
+    def test_non_string_name_falls_back(self):
+        """Passing a non-string (e.g. an ORM object) should fall back to ClassicScoring."""
+        scoring = get_scoring_system(42)
+        assert isinstance(scoring, ClassicScoring)
+
+    def test_config_with_falsy_values(self):
+        """Config dict with falsy values (0, 0.0) should still be applied, not treated as empty."""
+        scoring = get_scoring_system("Classic", config={"first_val": 0, "jury_val": 0.0})
+        assert scoring.config["first_val"] == 0
+        assert scoring.config["jury_val"] == 0.0
+
+    def test_partial_config_fills_defaults(self):
+        """Passing only some keys should fill the rest from defaults."""
+        scoring = get_scoring_system("Classic", config={"first_val": 99})
+        assert scoring.config["first_val"] == 99
+        assert scoring.config["jury_val"] == DEFAULT_CONFIG["jury_val"]
+
 
 # ── compute_stat_overrides ────────────────────────────────────────────────
 

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -822,7 +822,9 @@ class TestGetScoringSystem:
 
     def test_config_with_falsy_values(self):
         """Config dict with falsy values (0, 0.0) should still be applied, not treated as empty."""
-        scoring = get_scoring_system("Classic", config={"first_val": 0, "jury_val": 0.0})
+        scoring = get_scoring_system(
+            "Classic", config={"first_val": 0, "jury_val": 0.0}
+        )
         assert scoring.config["first_val"] == 0
         assert scoring.config["jury_val"] == 0.0
 


### PR DESCRIPTION
## Summary

- **#15 — votes_received wrong column**: `data.py` grouped Vote History by `vote_id` (the voter) instead of `voted_out_id` (the target). Every survivor's "votes against" stat was actually showing votes *cast*.
- **#16 — rules page wrong scoring config**: `routes.py` passed a `Season` ORM object to `get_scoring_system()` instead of the string name + config dict. The dict lookup silently missed and fell back to default config. Also fixed `if config:` → `if config is not None:` to handle empty config dicts correctly.
- **#17 — SQLite PRAGMAs not set**: Added `Engine` connect event listener to enable `PRAGMA foreign_keys=ON` (prevents orphan records) and `PRAGMA journal_mode=WAL` (prevents `database is locked` during scheduler writes).
- **#29 — seed.py import**: Already fixed in codebase (SoleSurvivorPick is imported at line 29).

## Test plan

- [x] 211/211 tests pass (`python -m pytest`) — up from 180
- [x] Snyk code scan clean (only pre-existing CLI path traversal residuals)
- [x] `test_data.py` (18 tests): Verifies votes_against groups by target, with edge cases for split votes, unanimous votes, self-votes, empty DFs, plus confessional/challenge/advantage aggregation
- [x] `test_scoring.py` (5 new tests): Empty dict config, None config, non-string name fallback, falsy config values (0, 0.0), partial config fills defaults
- [x] `test_pragmas.py` (8 tests): FK enforcement raises IntegrityError on bogus season_id and user_id, WAL mode active on file-backed DB, PRAGMAs verified on raw DBAPI connection and after session cycling, DB isolation verified via temp path check

🤖 Generated with [Claude Code](https://claude.com/claude-code)