### PR TITLE
refactor: auto-diff schema sync + pick export safety net

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -22,40 +22,54 @@ def _set_sqlite_pragma(dbapi_connection, connection_record):
 
 
 def _add_missing_columns():
-    """Add columns that create_all() won't add to existing tables."""
+    """Auto-detect and add columns that exist in models but not in the database.
+
+    Compares SQLAlchemy model metadata against the actual schema and issues
+    ALTER TABLE ADD COLUMN for any missing columns.  Scalar Python-side
+    defaults (int, float, bool, str) are translated to SQL DEFAULT clauses
+    so existing rows get backfilled.
+    """
+    import logging
+
     import sqlalchemy
 
+    log = logging.getLogger(__name__)
     inspector = sqlalchemy.inspect(db.engine)
-    survivor_cols = {c["name"] for c in inspector.get_columns("survivor")}
-    new_cols = {
-        "elimination_episode": "INTEGER",
-        "episode_stats": "TEXT",
-        "tribal_councils_attended": "INTEGER DEFAULT 0",
-        "correct_votes": "INTEGER DEFAULT 0",
-        "votes_nullified": "INTEGER DEFAULT 0",
-        "confessional_time": "REAL DEFAULT 0",
-        "sit_outs": "INTEGER DEFAULT 0",
-        "jury_votes_received": "INTEGER",
-        "performance_score": "REAL",
-        "day_voted_out": "INTEGER",
-    }
-    with db.engine.begin() as conn:
-        for col, col_type in new_cols.items():
-            if col not in survivor_cols:
-                conn.execute(
-                    sqlalchemy.text(f"ALTER TABLE survivor ADD COLUMN {col} {col_type}")
-                )
-    # Season table columns
-    season_cols = {c["name"] for c in inspector.get_columns("season")}
-    season_new = {
-        "merge_episode_num": "INTEGER",
-    }
-    with db.engine.begin() as conn:
-        for col, col_type in season_new.items():
-            if col not in season_cols:
-                conn.execute(
-                    sqlalchemy.text(f"ALTER TABLE season ADD COLUMN {col} {col_type}")
-                )
+    dialect = db.engine.dialect
+
+    for table in db.Model.metadata.sorted_tables:
+        if not inspector.has_table(table.name):
+            continue  # create_all() handles entirely new tables
+
+        existing_cols = {c["name"] for c in inspector.get_columns(table.name)}
+        added = []
+
+        with db.engine.begin() as conn:
+            for column in table.columns:
+                if column.name in existing_cols:
+                    continue
+
+                col_type = column.type.compile(dialect=dialect)
+                stmt = f"ALTER TABLE {table.name} ADD COLUMN {column.name} {col_type}"
+
+                # Translate scalar Python-side defaults to SQL DEFAULT so
+                # existing rows are backfilled (ORM default= only applies to
+                # new INSERTs, not ALTER TABLE).
+                if column.default is not None and column.default.is_scalar:
+                    val = column.default.arg
+                    if isinstance(val, bool):
+                        stmt += f" DEFAULT {int(val)}"
+                    elif isinstance(val, (int, float)):
+                        stmt += f" DEFAULT {val}"
+                    elif isinstance(val, str):
+                        escaped = val.replace("'", "''")
+                        stmt += f" DEFAULT '{escaped}'"
+
+                conn.execute(sqlalchemy.text(stmt))
+                added.append(column.name)
+
+        if added:
+            log.info("Added columns to %s: %s", table.name, ", ".join(added))
 
 
 def create_app():

--- a/seed.py
+++ b/seed.py
@@ -400,14 +400,28 @@ def generate_image_urls():
         print(f"  Season {season.number}: {matched}/{total} images")
 
 
-# Map of season number → pick JSON filename (for --picks-dir loading)
-SEASON_PICK_FILES = {
-    45: "season45.json",
-    46: "season46.json",
-    47: "season47_snakedraft.json",
-    49: "season49_snakedraft.json",
-    50: "season50_snakedraft.json",
-}
+def discover_pick_files(picks_dir):
+    """Auto-discover pick JSON files in a directory.
+
+    Scans for season*.json files and extracts the season number from the
+    filename.  When multiple files match the same season (e.g. season47.json
+    and season47_snakedraft.json), the canonical ``season{N}.json`` name wins
+    — this is the format produced by ``export_season_picks()``.
+    """
+    import glob
+    import re
+
+    files = {}
+    for path in sorted(glob.glob(os.path.join(picks_dir, "season*.json"))):
+        basename = os.path.basename(path)
+        match = re.match(r"season(\d+)", basename)
+        if not match:
+            continue
+        num = int(match.group(1))
+        # Prefer exact season{N}.json (auto-exported) over suffixed variants
+        if num not in files or basename == f"season{num}.json":
+            files[num] = path
+    return files
 
 
 def main():
@@ -444,6 +458,19 @@ def main():
 
     app = create_app()
     with app.app_context():
+        # Safety net: export all picks before dropping tables
+        try:
+            from app.data import export_all_picks
+
+            exported = export_all_picks()
+            if exported:
+                print(f"Auto-exported picks for {len(exported)} season(s) to picks/")
+                for p in exported:
+                    print(f"  {p}")
+        except Exception as e:
+            # First run or empty DB — nothing to export
+            print(f"Pick export skipped: {e}")
+
         print("Dropping and recreating all tables...")
         db.drop_all()
         db.create_all()
@@ -477,16 +504,14 @@ def main():
                 print(f"Error: --picks-dir {picks_dir} is not a directory")
                 sys.exit(1)
             print(f"\nLoading pick assignments from {picks_dir}...")
-            for snum, filename in SEASON_PICK_FILES.items():
-                filepath = os.path.realpath(os.path.join(picks_dir, filename))
+            discovered = discover_pick_files(picks_dir)
+            for snum, filepath in sorted(discovered.items()):
+                filepath = os.path.realpath(filepath)
                 if not filepath.startswith(picks_dir):
-                    print(f"  Skipping {filename}: path escapes picks directory")
+                    print(f"  Skipping {os.path.basename(filepath)}: path escapes picks directory")
                     continue
                 season = Season.query.filter_by(number=snum).first()
                 if not season:
-                    continue
-                if not os.path.exists(filepath):
-                    print(f"  Skipping season {snum}: {filepath} not found")
                     continue
                 survivor_map = {
                     s.name.lower(): s

--- a/tests/test_schema_sync.py
+++ b/tests/test_schema_sync.py
@@ -1,0 +1,265 @@
+"""Tests for auto-diff schema sync (_add_missing_columns) and pick file discovery."""
+
+import importlib
+import json
+import os
+import sys
+
+import pytest
+from sqlalchemy import text
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def app(tmp_path, monkeypatch):
+    """Flask app with a temp file-backed SQLite DB."""
+    db_path = tmp_path / "test.db"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+
+    if "config" in sys.modules:
+        importlib.reload(sys.modules["config"])
+
+    monkeypatch.setattr("app.scheduler.init_scheduler", lambda _app: None)
+
+    from app import create_app, db
+
+    application = create_app()
+    application.config["TESTING"] = True
+    with application.app_context():
+        yield application, db
+        db.session.remove()
+
+    if "config" in sys.modules:
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        importlib.reload(sys.modules["config"])
+
+
+# ── Auto-diff _add_missing_columns ────────────────────────────────────────
+
+
+class TestAddMissingColumns:
+    def test_all_model_columns_exist_after_create_app(self, app):
+        """create_all() + _add_missing_columns() should produce all model columns."""
+        _, db = app
+        import sqlalchemy
+
+        inspector = sqlalchemy.inspect(db.engine)
+        for table in db.Model.metadata.sorted_tables:
+            actual_cols = {c["name"] for c in inspector.get_columns(table.name)}
+            expected_cols = {c.name for c in table.columns}
+            missing = expected_cols - actual_cols
+            assert not missing, f"Table {table.name} missing columns: {missing}"
+
+    def test_adds_column_to_existing_table(self, app):
+        """If a column is dropped from the DB, _add_missing_columns re-adds it."""
+        _, db = app
+
+        # Drop a known column
+        with db.engine.begin() as conn:
+            # SQLite >= 3.35.0 supports DROP COLUMN
+            conn.execute(text("ALTER TABLE survivor DROP COLUMN won_fire"))
+
+        # Verify it's gone
+        import sqlalchemy
+
+        inspector = sqlalchemy.inspect(db.engine)
+        cols = {c["name"] for c in inspector.get_columns("survivor")}
+        assert "won_fire" not in cols
+
+        # Run the sync
+        from app import _add_missing_columns
+
+        _add_missing_columns()
+
+        # Verify it's back
+        inspector = sqlalchemy.inspect(db.engine)
+        cols = {c["name"] for c in inspector.get_columns("survivor")}
+        assert "won_fire" in cols
+
+    def test_scalar_default_backfills_existing_rows(self, app):
+        """Columns with scalar defaults should backfill existing rows via SQL DEFAULT."""
+        _, db = app
+        from app.models import Season
+
+        # Insert a season, then drop a column with a default
+        season = Season(number=99, name="Test", num_players=18)
+        db.session.add(season)
+        db.session.commit()
+
+        with db.engine.begin() as conn:
+            conn.execute(text("ALTER TABLE survivor DROP COLUMN won_fire"))
+
+        # Re-add via sync
+        from app import _add_missing_columns
+
+        _add_missing_columns()
+
+        # Insert a survivor and verify the default is applied at DB level
+        # (the ALTER TABLE DEFAULT clause backfills existing rows in SQLite)
+        with db.engine.begin() as conn:
+            conn.execute(
+                text(
+                    "INSERT INTO survivor (season_id, name, voted_out_order) "
+                    "VALUES (:sid, :name, 0)"
+                ),
+                {"sid": season.id, "name": "TestPlayer"},
+            )
+            row = conn.execute(
+                text("SELECT won_fire FROM survivor WHERE name = 'TestPlayer'")
+            ).fetchone()
+        assert row[0] == 0  # False → DEFAULT 0
+
+    def test_idempotent_on_complete_schema(self, app):
+        """Running _add_missing_columns on an already-complete schema is a no-op."""
+        _, db = app
+        import sqlalchemy
+
+        from app import _add_missing_columns
+
+        # Get column counts before
+        inspector = sqlalchemy.inspect(db.engine)
+        before = {
+            t.name: len(inspector.get_columns(t.name))
+            for t in db.Model.metadata.sorted_tables
+        }
+
+        # Run again — should be a no-op
+        _add_missing_columns()
+
+        inspector = sqlalchemy.inspect(db.engine)
+        after = {
+            t.name: len(inspector.get_columns(t.name))
+            for t in db.Model.metadata.sorted_tables
+        }
+        assert before == after
+
+    def test_string_default_applied(self, app):
+        """String defaults (like scoring_config='{}') should be quoted in SQL."""
+        _, db = app
+
+        with db.engine.begin() as conn:
+            conn.execute(text("ALTER TABLE season DROP COLUMN scoring_config"))
+
+        from app import _add_missing_columns
+
+        _add_missing_columns()
+
+        # Insert a row without specifying scoring_config
+        with db.engine.begin() as conn:
+            conn.execute(
+                text(
+                    "INSERT INTO season (number, name, num_players) "
+                    "VALUES (99, 'Test', 18)"
+                )
+            )
+            row = conn.execute(
+                text("SELECT scoring_config FROM season WHERE number = 99")
+            ).fetchone()
+        assert row[0] == "{}"
+
+
+# ── Pick file discovery ───────────────────────────────────────────────────
+
+
+class TestDiscoverPickFiles:
+    def test_discovers_simple_files(self, tmp_path):
+        """Finds season{N}.json files and extracts season numbers."""
+        from seed import discover_pick_files
+
+        (tmp_path / "season45.json").write_text("{}")
+        (tmp_path / "season50.json").write_text("{}")
+
+        result = discover_pick_files(str(tmp_path))
+        assert result == {
+            45: str(tmp_path / "season45.json"),
+            50: str(tmp_path / "season50.json"),
+        }
+
+    def test_prefers_canonical_over_suffixed(self, tmp_path):
+        """season47.json should win over season47_snakedraft.json."""
+        from seed import discover_pick_files
+
+        (tmp_path / "season47_snakedraft.json").write_text('{"old": true}')
+        (tmp_path / "season47.json").write_text('{"new": true}')
+
+        result = discover_pick_files(str(tmp_path))
+        assert result[47] == str(tmp_path / "season47.json")
+
+    def test_falls_back_to_suffixed(self, tmp_path):
+        """If only a suffixed file exists, it should still be found."""
+        from seed import discover_pick_files
+
+        (tmp_path / "season49_snakedraft.json").write_text("{}")
+
+        result = discover_pick_files(str(tmp_path))
+        assert 49 in result
+        assert "snakedraft" in result[49]
+
+    def test_ignores_non_json(self, tmp_path):
+        """Non-JSON files and xlsx files should be ignored."""
+        from seed import discover_pick_files
+
+        (tmp_path / "season46.xlsx").write_text("")
+        (tmp_path / "season46.json").write_text("{}")
+        (tmp_path / "README.md").write_text("")
+
+        result = discover_pick_files(str(tmp_path))
+        assert list(result.keys()) == [46]
+
+    def test_empty_directory(self, tmp_path):
+        """Empty directory returns empty dict."""
+        from seed import discover_pick_files
+
+        result = discover_pick_files(str(tmp_path))
+        assert result == {}
+
+
+# ── seed.py auto-export integration ───────────────────────────────────────
+
+
+class TestSeedAutoExport:
+    def test_export_season_picks_roundtrip(self, app, tmp_path):
+        """Picks exported via export_season_picks can be re-imported."""
+        _, db = app
+        from app.data import export_season_picks
+        from app.models import Pick, Season, Survivor, User
+
+        # Create test data
+        season = Season(number=99, name="Test", num_players=18)
+        db.session.add(season)
+        db.session.flush()
+
+        user = User(username="testplayer", display_name="TestPlayer")
+        db.session.add(user)
+        db.session.flush()
+
+        surv = Survivor(season_id=season.id, name="Castaway", voted_out_order=1)
+        db.session.add(surv)
+        db.session.flush()
+
+        pick = Pick(
+            user_id=user.id,
+            season_id=season.id,
+            survivor_id=surv.id,
+            pick_type="draft",
+            pick_order=1,
+        )
+        db.session.add(pick)
+        db.session.commit()
+
+        # Export
+        path = export_season_picks(season, str(tmp_path))
+        assert path is not None
+        assert os.path.exists(path)
+
+        # Verify JSON structure
+        with open(path) as f:
+            data = json.load(f)
+
+        assert "picks" in data
+        assert "TestPlayer" in data["picks"]
+        assert data["picks"]["TestPlayer"][0]["survivor"] == "Castaway"
+        assert data["picks"]["TestPlayer"][0]["type"] == "d"
+        assert data["picks"]["TestPlayer"][0]["order"] == 1


### PR DESCRIPTION
## Summary
- **Auto-diff `_add_missing_columns()`**: Replaced hand-maintained column dict with automatic detection — compares SQLAlchemy model metadata against actual DB schema and adds missing columns with proper defaults. No more manual maintenance when adding columns to models.
- **seed.py pick safety net**: Auto-exports all picks to `picks/` before `db.drop_all()`, so reseeds never lose pick data.
- **Auto-discover pick files**: Replaced hardcoded `SEASON_PICK_FILES` dict with glob-based discovery. Prefers canonical `season{N}.json` (export format) over suffixed variants like `season47_snakedraft.json`.

Closes #5 — chose a lighter-weight approach over Alembic since the project is single-deployment SQLite with rebuildable data. See issue discussion for the trade-off analysis.

## Test plan
- [x] 11 new tests covering auto-diff column detection, default backfilling, pick file discovery, and export roundtrip
- [x] Full suite: 222 passed, 0 failed
- [x] Snyk SAST: no new findings (3 pre-existing in `analyze_scoring.py`)